### PR TITLE
Retain old format of mariadb config

### DIFF
--- a/migrations/container/20201103094726_service-command_configure_my_cnf.php
+++ b/migrations/container/20201103094726_service-command_configure_my_cnf.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EE\Migration;
+
+use EE;
+
+class ConfigureMyCNF extends Base {
+
+	/** @var RevertableStepProcessor $rsp Keeps track of migration state. Reverts on error */
+	private static $rsp;
+
+	public function __construct() {
+
+		parent::__construct();
+		if ( $this->is_first_execution ) {
+			$this->skip_this_migration = true;
+		}
+	}
+
+	/**
+	 * Execute global service container name update.
+	 *
+	 * @throws EE\ExitException
+	 */
+	public function up() {
+
+		if ( $this->skip_this_migration ) {
+			EE::debug( 'Skipping configure-my-cnf migration as it is not needed.' );
+			return;
+		}
+
+		EE::debug( 'Starting configure-my-cnf' );
+
+		$my_cnf = EE_SERVICE_DIR . '/mariadb/conf/my.cnf';
+
+		if ( is_link( $my_cnf ) ) {
+			unlink( readlink( $my_cnf ) );
+			unlink( $my_cnf );
+
+			EE::exec('rm -f ' . EE_SERVICE_DIR . '/mariadb/conf/mariadb.conf.d/*.cnf' );
+
+		}
+	}
+
+	/**
+	 * No need for down.
+	 *
+	 * @throws EE\ExitException
+	 */
+	public function down() {
+	}
+}

--- a/templates/my.cnf.mustache
+++ b/templates/my.cnf.mustache
@@ -1,46 +1,133 @@
-# MariaDB database server configuration file.
+# The MariaDB configuration file
 #
-# You can copy this file to one of:
-# - "/etc/mysql/my.cnf" to set global options,
-# - "~/.my.cnf" to set user-specific options.
-# 
+# The MariaDB/MySQL tools read configuration files in the following order:
+# 1. "/etc/mysql/my.cnf" (this file) to set global defaults,
+# 2. "/etc/mysql/conf.d/*.cnf" to set global options.
+# 3. "/etc/mysql/mariadb.conf.d/*.cnf" to set MariaDB-only options.
+# 4. "~/.my.cnf" to set user-specific options.
+#
+# If the same option is defined multiple times, the last one will apply.
+#
 # One can use all long options that the program supports.
 # Run program with --help to get a list of available options and with
 # --print-defaults to see which it would actually understand and use.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
 
+#
+# This group is read both by the client and the server
+# use it for options that affect everything
+#
+[client-server]
+
+socket                  = /run/mysqld/mysqld.sock
+port                    = 3306
+
+#
+# This group is read by the client library
+# Use it for options that affect all clients, but not the server
+#
+
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+default-character-set = utf8mb4
+
+# Example of client certificate usage
+# ssl-cert=/etc/mysql/client-cert.pem
+# ssl-key=/etc/mysql/client-key.pem
+#
+# Allow only TLS encrypted connections
+# ssl-verify-server-cert=on
+
+# This group is *never* read by mysql client library, though this
+# /etc/mysql/mariadb.cnf.d/client.cnf file is not read by Oracle MySQL
+# client anyway.
+# If you use the same .cnf file for MySQL and MariaDB,
+# use it for MariaDB-only client options
+[client-mariadb]
+
+#
+# These groups are read by MariaDB command-line tools
+# Use it for options that affect only one utility
+#
+
+[mysql]
+
+[mysql_upgrade]
+
+[mysqladmin]
+
+[mysqlbinlog]
+
+[mysqlcheck]
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysqlimport]
+
+[mysqlshow]
+
+[mysqlslap]
+
+# NOTE: THIS FILE IS READ ONLY BY THE TRADITIONAL SYSV INIT SCRIPT, NOT SYSTEMD.
+# MARIADB SYSTEMD DOES _NOT_ UTILIZE MYSQLD_SAFE NOR READ THIS FILE.
+#
+# For similar behavior, systemd users should create the following file:
+# /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
+#
+# To achieve the same result as the default 50-mysqld_safe.cnf, please create
+# /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
+# with the following contents:
+#
+# [Service]
+# User=mysql
+# StandardOutput=syslog
+# StandardError=syslog
+# SyslogFacility=daemon
+# SyslogLevel=err
+# SyslogIdentifier=mysqld
+#
+# For more information, please read https://mariadb.com/kb/en/mariadb/systemd/
+
+[mysqld_safe]
 # This will be passed to all mysql clients
 # It has been reported that passwords should be enclosed with ticks/quotes
-# escpecially if they contain "#" chars...
-# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
-[client]
-port		= 3306
-socket		= /var/run/mysqld/mysqld.sock
+# especially if they contain "#" chars...
+socket  = /var/run/mysqld/mysqld.sock
+nice    = 0
+skip_log_error
+syslog
 
-# Here is entries for some specific programs
-# The following values assume you have at least 32M ram
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
 
-# This was formally known as [safe_mysqld]. Both versions are currently parsed.
-[mysqld_safe]
-socket		= /var/run/mysqld/mysqld.sock
-nice		= 0
+# this is read by the standalone daemon and embedded servers
+[server]
 
+# this is only for the mysqld standalone daemon
 [mysqld]
+
 #
 # * Basic Settings
 #
-#user		= mysql
-pid-file	= /var/run/mysqld/mysqld.pid
-socket		= /var/run/mysqld/mysqld.sock
-port		= 3306
-basedir		= /usr
-datadir		= /var/lib/mysql
-tmpdir		= /tmp
-lc_messages_dir	= /usr/share/mysql
-lc_messages	= en_US
+
+#user                   = mysql
+pid-file                = /run/mysqld/mysqld.pid
+socket                  = /var/run/mysqld/mysqld.sock
+port                    = 3306
+basedir                 = /usr
+datadir                 = /var/lib/mysql
+tmpdir                  = /tmp
+lc-messages-dir         = /usr/share/mysql
+lc-messages             = en_US
 skip-external-locking
+
+# Broken reverse DNS slows down connections considerably and name resolve is
+# safe to skip if there are no "host by domain name" access grants
+#skip-name-resolve
+
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
@@ -78,58 +165,56 @@ query_cache_limit		= 128K
 query_cache_size		= 64M
 # for more write intensive setups, set to DEMAND or OFF
 #query_cache_type		= DEMAND
+
 #
 # * Logging and Replication
 #
+
 # Both location gets rotated by the cronjob.
 # Be aware that this log type is a performance killer.
-# As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
-#
-# Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
-#
+# Recommend only changing this at runtime for short testing periods if needed!
+#general_log_file       = /var/log/mysql/mysql.log
+#general_log            = 1
+
+# When running under systemd, error logging goes via stdout/stderr to journald
+# and when running legacy init error logging goes to syslog due to
+# /etc/mysql/conf.d/mariadb.conf.d/50-mysqld_safe.cnf
+# Enable this if you want to have error logging into a separate file
 # we do want to know about network errors and such
 #log_warnings		= 2
-#
+#log_error = /var/log/mysql/error.log
 # Enable the slow query log to see queries with especially long duration
 #slow_query_log[={0|1}]
-slow_query_log_file	= /var/log/mysql/mariadb-slow.log
-long_query_time = 10
+slow_query_log_file     = /var/log/mysql/mariadb-slow.log
+long_query_time         = 10
 #log_slow_rate_limit	= 1000
-#log_slow_verbosity	= query_plan
-
+#log_slow_verbosity     = query_plan,explain
 #log-queries-not-using-indexes
 #log_slow_admin_statements
-#
+#min_examined_row_limit = 1000
+
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
 #       other settings you may need to change.
-#server-id		= 1
-#report_host		= master1
-#auto_increment_increment = 2
-#auto_increment_offset	= 1
-#log_bin			= /var/log/mysql/mariadb-bin
-#log_bin_index		= /var/log/mysql/mariadb-bin.index
-# not fab for performance, but safer
-#sync_binlog		= 1
-expire_logs_days	= 10
-max_binlog_size         = 100M
-# slaves
-#relay_log		= /var/log/mysql/relay-bin
-#relay_log_index	= /var/log/mysql/relay-bin.index
-#relay_log_info_file	= /var/log/mysql/relay-bin.info
-#log_slave_updates
-#read_only
+#server-id              = 1
+#log_bin                = /var/log/mysql/mysql-bin.log
+expire_logs_days        = 10
+#max_binlog_size        = 100M
+
 #
 # If applications support it, this stricter sql_mode prevents some
 # mistakes like inserting invalid dates etc.
 #sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+
 #
 # * InnoDB
 #
+
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
+# Most important is to give InnoDB 80 % of the system RAM for buffer use:
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_buffer_pool_size
+
 default_storage_engine	= InnoDB
 # you can't just change log file size, requires special procedure
 #innodb_log_file_size	= 50M
@@ -139,21 +224,43 @@ innodb_file_per_table	= 1
 innodb_open_files	= 400
 innodb_io_capacity	= 400
 innodb_flush_method	= O_DIRECT
-#
-# * Security Features
-#
-# Read the manual, too, if you want chroot!
-# chroot = /var/lib/mysql/
-#
-# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
-#
-# ssl-ca=/etc/mysql/cacert.pem
-# ssl-cert=/etc/mysql/server-cert.pem
-# ssl-key=/etc/mysql/server-key.pem
 
+#
+# * SSL/TLS
+#
+
+# For documentation, please read
+# https://mariadb.com/kb/en/securing-connections-for-client-and-server/
+#ssl-ca = /etc/mysql/cacert.pem
+#ssl-cert = /etc/mysql/server-cert.pem
+#ssl-key = /etc/mysql/server-key.pem
+
+#
+# * Character sets
+#
+
+# MySQL/MariaDB default is Latin1, but in Debian we rather default to the full
+# utf8 4-byte character set. See also client.cnf
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_general_ci
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+# This group is only read by MariaDB-10.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mariadb-10.5]
 #
 # * Galera-related settings
 #
+# See the examples of server wsrep.cnf files in /usr/share/mysql
+
 [galera]
 # Mandatory settings
 #wsrep_on=ON
@@ -162,22 +269,13 @@ innodb_flush_method	= O_DIRECT
 #binlog_format=row
 #default_storage_engine=InnoDB
 #innodb_autoinc_lock_mode=2
-#
+
 # Allow server to accept connections on all interfaces.
-#
 #bind-address=0.0.0.0
-#
-# Optional setting
+
+# Optional settings
 #wsrep_slave_threads=1
 #innodb_flush_log_at_trx_commit=0
-
-[mysqldump]
-quick
-quote-names
-max_allowed_packet	= 16M
-
-[mysql]
-#no-auto-rehash	# faster start of mysql but no tab completion
 
 [isamchk]
 key_buffer		= 16M
@@ -187,3 +285,4 @@ key_buffer		= 16M
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
 !includedir /etc/mysql/conf.d/
+!includedir /etc/mysql/mariadb.conf.d/


### PR DESCRIPTION
This fix ensures that servers, where EE was installed in the last update(v4.1.5), have a config structure that is consistent with older versions.

We have also taken this opportunity to update the config file and we've ported the latest changes in config from the MariaDB release to this config.